### PR TITLE
Expose dva-processing in test-env

### DIFF
--- a/test-env/compose.yml
+++ b/test-env/compose.yml
@@ -59,6 +59,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 3
+    ports: [5007:5000]
     depends_on:
       rabbit-consumer: {condition: service_healthy}
       postgres-provider: {condition: service_healthy}
@@ -76,6 +77,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 3
+    ports: [5008:5000]
     depends_on:
       rabbit-consumer: {condition: service_healthy}
       postgres-consumer: {condition: service_healthy}


### PR DESCRIPTION
Adjusts `test-env/compose.yml` so the dva-processing provider and consumer services bind to host ports 5007 and 5008 respectively, matching the endpoints expected by the slimmed-down dva-api orchestrator in companion PRs.

Depends on: none

@bzp99